### PR TITLE
missing brew install textinfo

### DIFF
--- a/build_toolchain_macos.md
+++ b/build_toolchain_macos.md
@@ -26,6 +26,12 @@ The build requires some of the GNU coreutils and not the BSD equivalents that co
 
 `$ brew install coreutils`
 
+### textinfo
+
+The build require textinfo to build
+
+`$ brew install texinfo`
+
 ## Check out the sources
 
 ```


### PR DESCRIPTION
The build failed with
```
xuantie-gnu-toolchain/riscv-gdb/missing: line 81: makeinfo: command not found
```

I install textinfo and it solve the issue